### PR TITLE
Upgrade Python version to 3.12

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,6 +1,6 @@
 {
   "name": "slack-app",
-  "image": "mcr.microsoft.com/devcontainers/python:3.12-bullseye",
+  "image": "mcr.microsoft.com/devcontainers/python:3.12-bookworm",
 
   "features": {
     "ghcr.io/devcontainers/features/common-utils:2": {

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,6 +1,6 @@
 {
-  "name": "slack-app-3-10",
-  "image": "mcr.microsoft.com/devcontainers/python:3.10-bullseye",
+  "name": "slack-app",
+  "image": "mcr.microsoft.com/devcontainers/python:3.12-bullseye",
 
   "features": {
     "ghcr.io/devcontainers/features/common-utils:2": {

--- a/.github/ISSUE_TEMPLATE/issue-bug.yml
+++ b/.github/ISSUE_TEMPLATE/issue-bug.yml
@@ -47,8 +47,8 @@ body:
     label: Environment
     description: |
       examples:
-        - **OS**: Ubuntu 20.04
-        - **Python version**: 3.10.11
+        - **OS**: Ubuntu 22.04
+        - **Python version**: 3.12.3
         - **slack-bolt**: 1.17.1
         - **slack-sdk**: 3.21.1
     value: |

--- a/.github/ISSUE_TEMPLATE/issue-feature.yml
+++ b/.github/ISSUE_TEMPLATE/issue-feature.yml
@@ -30,8 +30,8 @@ body:
     label: Environment
     description: |
       examples:
-        - **OS**: Ubuntu 20.04
-        - **Python version**: 3.10.11
+        - **OS**: Ubuntu 22.04
+        - **Python version**: 3.12.3
     value: |
         - OS:
         - Python version:

--- a/.github/workflows/python-run-tests.yml
+++ b/.github/workflows/python-run-tests.yml
@@ -1,7 +1,7 @@
 # This workflow will install Python dependencies, run tests and lint with a single version of Python
 # For more information see: https://docs.github.com/en/actions/automating-builds-and-tests/building-and-testing-python
 
-name: "Run tests and lint (Python 3.10)"
+name: "Run tests and lint (Python 3.12)"
 
 on:
   push:
@@ -20,10 +20,10 @@ jobs:
 
     steps:
     - uses: actions/checkout@v4
-    - name: Set up Python 3.10
+    - name: Set up Python 3.12
       uses: actions/setup-python@v4
       with:
-        python-version: "3.10"
+        python-version: "3.12"
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip

--- a/.github/workflows/snyk.yml
+++ b/.github/workflows/snyk.yml
@@ -1,4 +1,4 @@
-name: "Snyk (Python 3.10)"
+name: "Snyk (Python)"
 
 on:
   push:
@@ -12,7 +12,7 @@ jobs:
     steps:
       - uses: actions/checkout@master
       - name: Run Snyk to check for vulnerabilities
-        uses: snyk/actions/python-3.10@master
+        uses: snyk/actions/python@master
         continue-on-error: true # To make sure that SARIF upload gets called
         env:
           SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 # syntax=docker/dockerfile:1
 
-FROM python:3.12-slim-bullseye AS base
+FROM python:3.12-slim-bookworm AS base
 RUN apt-get update && \
     apt-get install liblzma-dev -y
 RUN adduser --disabled-login --gecos "" slack-app

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 # syntax=docker/dockerfile:1
 
-FROM python:3.10-slim-bullseye AS base
+FROM python:3.12-slim-bullseye AS base
 RUN apt-get update && \
     apt-get install liblzma-dev -y
 RUN adduser --disabled-login --gecos "" slack-app

--- a/docs/development.md
+++ b/docs/development.md
@@ -35,11 +35,11 @@ cd $(pyenv root)/plugins/pyenv-virtualenv && git pull && cd -
 sudo apt update && \
     sudo apt install liblzma-dev
 
-# find the latest 3.10.x version available in pyenv
-export PY_VERSION=$(pyenv install -l | grep "^\s*3.10" | tail -n 1 | awk '{print $1}') && \
+# find the latest 3.12.x version available in pyenv
+export PY_VERSION=$(pyenv install -l | grep "^\s*3.12" | tail -n 1 | awk '{print $1}') && \
     echo $PY_VERSION
 
-# install the latest 3.10.x release
+# install the latest 3.12.x release
 pyenv install $PY_VERSION
 
 # create a virtual environment
@@ -79,6 +79,11 @@ See also [the pre-commit tips section in miscellanea.md](miscellanea.md#pre-comm
 
 ## start slack-app in debug mode
 
+Export the environment variables
+```shell
+source ~/.secrets/ENV_VARS
+```
+
 Run `app.py` in debug mode
 ```shell
 export SLACK_BOT_DEBUG=true && \
@@ -103,7 +108,7 @@ It is possible to [run tests with docker](#run-the-tests-with-docker), or manual
 ```
 (slack-app-venv) (...):~/github/slack-app$ pytest
 ========================= test session starts =========================
-platform linux -- Python 3.10.11, pytest-7.3.1, pluggy-1.0.0
+platform linux -- Python 3.12.3, pytest-7.3.1, pluggy-1.0.0
 rootdir: /home/user/github/slack-app
 collected 1 item
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,7 +9,7 @@ authors = [
 ]
 description = "A simple Slack app"
 readme = "README.md"
-requires-python = ">=3.10"
+requires-python = ">=3.12"
 classifiers = [
     "Programming Language :: Python :: 3",
     "License :: OSI Approved :: MIT License",


### PR DESCRIPTION
Resolves #31 

- bump up the Python version from `3.10` to `3.12`
- bump up the Debian base image from `bullseye` to `bookworm`
- update `pyproject.toml`
- update the template examples to match the new Python version and a newer version of OS
- update the documentation and the examples in particular
- update the GH Actions to match the new Python version
- as for Snyk, I couldn't find a `3.12` action so switched to what seems the default `snyk/actions/python@master`