### PR TITLE
Bump `codeql-action/upload-sarif` to v3

### DIFF
--- a/.github/workflows/snyk.yml
+++ b/.github/workflows/snyk.yml
@@ -19,6 +19,6 @@ jobs:
         with:
           args: --sarif-file-output=snyk.sarif --severity-threshold=high
       - name: Upload result to GitHub Code Scanning
-        uses: github/codeql-action/upload-sarif@v2
+        uses: github/codeql-action/upload-sarif@v3
         with:
           sarif_file: snyk.sarif


### PR DESCRIPTION
... as v1 and v2 have been deprecated.

See https://github.blog/changelog/2025-01-10-code-scanning-codeql-action-v2-is-now-deprecated/