### PR TITLE
Bump up the Python version to 3.13.3

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,6 +1,6 @@
 {
   "name": "slack-app",
-  "image": "mcr.microsoft.com/devcontainers/python:3.12-bookworm",
+  "image": "mcr.microsoft.com/devcontainers/python:3.13-bookworm",
 
   "features": {
     "ghcr.io/devcontainers/features/common-utils:2": {

--- a/.github/ISSUE_TEMPLATE/issue-bug.yml
+++ b/.github/ISSUE_TEMPLATE/issue-bug.yml
@@ -48,7 +48,7 @@ body:
     description: |
       examples:
         - **OS**: Ubuntu 22.04
-        - **Python version**: 3.12.3
+        - **Python version**: 3.13.3
         - **slack-bolt**: 1.17.1
         - **slack-sdk**: 3.21.1
     value: |

--- a/.github/ISSUE_TEMPLATE/issue-feature.yml
+++ b/.github/ISSUE_TEMPLATE/issue-feature.yml
@@ -31,7 +31,7 @@ body:
     description: |
       examples:
         - **OS**: Ubuntu 22.04
-        - **Python version**: 3.12.3
+        - **Python version**: 3.13.3
     value: |
         - OS:
         - Python version:

--- a/.github/workflows/python-run-tests.yml
+++ b/.github/workflows/python-run-tests.yml
@@ -1,7 +1,7 @@
 # This workflow will install Python dependencies, run tests and lint with a single version of Python
 # For more information see: https://docs.github.com/en/actions/automating-builds-and-tests/building-and-testing-python
 
-name: "Run tests and lint (Python 3.12)"
+name: "Run tests and lint (Python 3.13)"
 
 on:
   push:
@@ -20,10 +20,10 @@ jobs:
 
     steps:
     - uses: actions/checkout@v4
-    - name: Set up Python 3.12
+    - name: Set up Python 3.13
       uses: actions/setup-python@v4
       with:
-        python-version: "3.12"
+        python-version: "3.13"
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -4,7 +4,7 @@ exclude: ^(profiling/|tests/data/)
 
 repos:
 -   repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v4.6.0
+    rev: v5.0.0
     hooks:
     -   id: check-added-large-files
     -   id: check-ast
@@ -22,7 +22,7 @@ repos:
     -   id: trailing-whitespace
 
 -   repo: https://github.com/psf/black
-    rev: 24.4.2
+    rev: 25.1.0
     hooks:
     -   id: black
 
@@ -32,7 +32,7 @@ repos:
 #     -   id: pylint
 
 -   repo: https://github.com/pycqa/isort
-    rev: 5.13.2
+    rev: 6.0.1
     hooks:
     -   id: isort
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 # syntax=docker/dockerfile:1
 
-FROM python:3.12-slim-bookworm AS base
+FROM python:3.13.3-slim-bookworm AS base
 RUN apt-get update && \
     apt-get install liblzma-dev -y
 RUN adduser --disabled-login --gecos "" slack-app

--- a/docs/development.md
+++ b/docs/development.md
@@ -35,11 +35,11 @@ cd $(pyenv root)/plugins/pyenv-virtualenv && git pull && cd -
 sudo apt update && \
     sudo apt install liblzma-dev
 
-# find the latest 3.12.x version available in pyenv
-export PY_VERSION=$(pyenv install -l | grep "^\s*3.12" | tail -n 1 | awk '{print $1}') && \
+# find the latest 3.13.x version available in pyenv
+export PY_VERSION=$(pyenv install -l | grep "^\s*3.13" | tail -n 1 | awk '{print $1}') && \
     echo $PY_VERSION
 
-# install the latest 3.12.x release
+# install the latest 3.13.x release
 pyenv install $PY_VERSION
 
 # create a virtual environment
@@ -88,14 +88,14 @@ Run `app.py` in debug mode
 ```shell
 export SLACK_BOT_DEBUG=true && \
     export PYTHONPATH=.; \
-    export SLACK_BOT_TOKEN; export SLACK_APP_TOKEN; python app.py
+    export SLACK_BOT_TOKEN; export SLACK_APP_TOKEN; python slackapp/app.py
 ```
 
 To switch off debug mode unset the env variable
 ```shell
 unset SLACK_BOT_DEBUG && \
     export PYTHONPATH=.; \
-    export SLACK_BOT_TOKEN; export SLACK_APP_TOKEN; python app.py
+    export SLACK_BOT_TOKEN; export SLACK_APP_TOKEN; python slackapp/app.py
 ```
 
 ## tests
@@ -108,7 +108,7 @@ It is possible to [run tests with docker](#run-the-tests-with-docker), or manual
 ```
 (slack-app-venv) (...):~/github/slack-app$ pytest
 ========================= test session starts =========================
-platform linux -- Python 3.12.3, pytest-7.3.1, pluggy-1.0.0
+platform linux -- Python 3.13.3, pytest-7.3.1, pluggy-1.0.0
 rootdir: /home/user/github/slack-app
 collected 1 item
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["setuptools>=61.0"]
+requires = ["setuptools>=78.1.1"]
 build-backend = "setuptools.build_meta"
 [project]
 name = "Slack-app"
@@ -9,7 +9,7 @@ authors = [
 ]
 description = "A simple Slack app"
 readme = "README.md"
-requires-python = ">=3.12"
+requires-python = ">=3.13"
 classifiers = [
     "Programming Language :: Python :: 3",
     "License :: OSI Approved :: MIT License",


### PR DESCRIPTION
This PR contains a number of version bumps, the main one being the Python version (`3.12.3` to `3.13.3`).

The container base image was upgraded as well, which should fix a Snyk security advisory ( resolves #54 ).

A small fix to the documentation that was previously missed is also included in this PR, as well as version bumps of various `pre-commit` hooks.